### PR TITLE
Remove link to hspec-meta

### DIFF
--- a/content/reference/languages/haskell/hspec.md
+++ b/content/reference/languages/haskell/hspec.md
@@ -4,20 +4,18 @@ tags:
   - haskell
   - testing
   - hspec
-  - hspec-meta
 ---
 
 # hspec Testing Framework
 
 ## Overview
 
-Qualified supports [hspec][2], a *Behavior Driven Development* (BDD) test framework for Haskell modeled after Ruby's popular [Rspec][3] framework.
+Qualified supports [hspec][1], a *Behavior Driven Development* (BDD) test framework for Haskell modeled after Ruby's popular [Rspec][2] framework.
 
 For more information, see: [https://hspec.github.io/][1]
 
 [1]: https://hspec.github.io/
-[2]: https://hackage.haskell.org/package/hspec-meta-1.10.0
-[3]: https://rspec.info/
+[2]: https://rspec.info/
 
 ## Setup
 


### PR DESCRIPTION
`hspec-meta` is "A version of Hspec which is used to test Hspec itself" (https://hackage.haskell.org/package/hspec-meta-1.10.0)

I mentioned this in https://github.com/qualified/qualified-docs/pull/42/files#r743428004, but was buried in the noise. GitHub should keep unresolved reviews visible :/