### PR TITLE
[QP-6215] Adds challenge preview dialog help

### DIFF
--- a/content/creating-content/challenges/challenge-preview.md
+++ b/content/creating-content/challenges/challenge-preview.md
@@ -1,0 +1,11 @@
+---
+private: true
+next: false
+prev: false
+---
+
+# Challenge Preview
+
+This preview can be used to quickly test and iterate on your challenge. It's not a perfect 1:1 experience with the final assessment, but you can easily validate tests and attempt different ways of solving your challenge.
+
+Some of the tabs here exist merely to showcase the full experience, such as the _Your Notes_ tab.

--- a/src/templates/MarkdownPage.vue
+++ b/src/templates/MarkdownPage.vue
@@ -11,7 +11,7 @@
 
                 <api-ref v-if="$page.markdownPage.apiRef" class="markdown-page__content" on-this-page />
 
-                <div class="markdown-page__end">
+                <div class="markdown-page__end" v-if="!private">
                     <NextPrevLinks/>
                 </div>
             </div>
@@ -60,6 +60,15 @@ export default {
         OnThisPage,
         NextPrevLinks,
     },
+
+    computed: {
+        private() {
+            const page = this.$page;
+            const edge = page.allMarkdownPage.edges.find(e => e.node.path === page.markdownPage.path);
+            return edge && edge.node && edge.node.private || false;
+        },
+    },
+
     metaInfo() {
         const title = this.$page.markdownPage.title;
         const description = this.$page.markdownPage.description || this.$page.markdownPage.excerpt;


### PR DESCRIPTION
This is just to provide some content for the challenge preview help pane, so you can show the correct layout when previewing. We can iterate on the content here if we need.

I also removed the Next/Prev links for all private docs, it doesn't make sense to show them at all in those cases.