### PR TITLE
Use strictEqual

### DIFF
--- a/content/reference/languages/javascript/mocha-bdd.md
+++ b/content/reference/languages/javascript/mocha-bdd.md
@@ -58,7 +58,7 @@ expect(tea).to.have.property('flavors').with.length(3);
 const {assert} = require("chai");
 
 assert.typeOf(foo, 'string');
-assert.equal(foo, 'bar');
+assert.strictEqual(foo, 'bar');
 assert.lengthOf(foo, 3)
 assert.property(tea, 'flavors');
 assert.lengthOf(tea.flavors, 3);

--- a/content/reference/languages/javascript/mocha-tdd.md
+++ b/content/reference/languages/javascript/mocha-tdd.md
@@ -57,7 +57,7 @@ expect(tea).to.have.property('flavors').with.length(3);
 const {assert} = require("chai");
 
 assert.typeOf(foo, 'string');
-assert.equal(foo, 'bar');
+assert.strictEqual(foo, 'bar');
 assert.lengthOf(foo, 3)
 assert.property(tea, 'flavors');
 assert.lengthOf(tea.flavors, 3);


### PR DESCRIPTION
Technically the type is already checked on the line prior here, but I figure good to encourage good practices in the common case where that line is absent.