### PR TITLE
Fix overflowing images

### DIFF
--- a/content/reference/markdown.md
+++ b/content/reference/markdown.md
@@ -291,11 +291,11 @@ Our most powerful documentation block. You use JSON to define a method, its argu
 
 This example would render as follows when viewing a Java challenge:
 
-<img src="https://www.evernote.com/l/AAW0Pg1N2h5LarPpk_v8SY79QM_BPCINEAIB/image.png" style="max-width: 700px" />
+<img src="https://www.evernote.com/l/AAW0Pg1N2h5LarPpk_v8SY79QM_BPCINEAIB/image.png" style="max-width: 100%" />
 
 And the same markdown would render as follows when viewing a Ruby challenge:
 
-<img src="https://www.evernote.com/l/AAWxBvhw47lKkJzXZC-ustDU11RxZipCmZsB/image.png" style="max-width: 700px" />
+<img src="https://www.evernote.com/l/AAWxBvhw47lKkJzXZC-ustDU11RxZipCmZsB/image.png" style="max-width: 100%" />
 
 
 ## Links


### PR DESCRIPTION
We've been using `max-width: 700px`, leading to overflow:

![Screenshot from 2023-06-18 21-39-10](https://github.com/andela-technology/qualified-docs/assets/17895165/4f66f01a-99f3-4e7d-abd6-b6fb2962ba9d)

The update uses `max-width: 100%`, ensuring the images never overflow the container.