### PR TITLE
Publish first product update since migration - January 2024

### DIFF
--- a/content/changes.md
+++ b/content/changes.md
@@ -8,20 +8,13 @@ summary: 'Learn about new features, fixes, and other improvements'
 
 Learn about notable new features, fixes, and other improvements to the application!
 
-## January, 2024 
+## January 31, 2024 
 
 ### Features 
  
 - **Learnosity Partnership Integration** 
 
-    [Learnosity](https://learnosity.com/) has officially announced our partnership and integration into their platform to their custom base, via website, newsletter, and socials! 
-
-    This integration allows us to expand our reach into the L&D space, acting as an important add-on component within Learnosity's deep offering across many different learning domains. We've closed our first partner sale via iCEV, and already have other potential deals beginning to surface.       We will be presenting internally to their sales team later this month to further deepen our partnership and enable their sales team to bring more business to us.  
-
-    [Release Announcement](https://help.learnosity.com/hc/en-us/articles/14870489871133-2024-1-LTS-Release-Announcement)
-
-    [Partner Page](https://learnosity.com/company/partners/partners-directory/qualified/)
-
+    [Qualified and Learnosity Partnership: Bridging the Skills Gap with Developer Assessments](https://andela.com/blog-posts/qualified-and-learnosity-partnership-bridging-the-skills-gap-with-developer-assessments)
 
 ### Improvements 
 
@@ -37,7 +30,11 @@ Learn about notable new features, fixes, and other improvements to the applicati
 
     A new "deprecated" label was added to old language versions in the challenge edit and detail views. This helps content managers identify which language versions will be removed in the future. For further information and tips on upgrading your content, please check our [guide for upgrading language versions](https://docs.qualified.io/creating-content/challenges/upgrading-language-versions/#upgrading-language-versions).
   
-- **Performance issue when loading "Portfolio" tab of report card** 
+- **Performance issue when loading "Portfolio" tab of report card**
+
+  :::note
+  Signal’s customers only
+  ::: 
 
     Users were experiencing heavy lag, especially with scrolls, once Portfolio tab was activated and the number of assessments results was exceeding 6 or more. This issue was successfully fixed.  
 
@@ -47,6 +44,9 @@ Learn about notable new features, fixes, and other improvements to the applicati
 
     This challenge tests the candidate's basic array and string manipulation.  
 
+:::info
+Note that Product Updates was on hiatus for 6 months. No major updates occurred during this time beyond standard bug fixes and challenges. We'll continue on a monthly basis going forward.
+:::
 
 ## July 13, 2023
 

--- a/content/changes.md
+++ b/content/changes.md
@@ -35,7 +35,7 @@ Learn about notable new features, fixes, and other improvements to the applicati
 
 - **Add deprecated language version labels** 
 
-    A new “deprecated” label was added on old language versions in the challenge edit and detail views, visible to teams and content managers with the purpose of providing our users with more legibility of what are the available language versions to use. For further information please check       our [documentation](https://docs.qualified.io/creating-content/challenges/upgrading-language-versions/#upgrading-language-versions) 
+    A new "deprecated" label was added to old language versions in the challenge edit and detail views. This helps content managers identify which language versions will be removed in the future. For further information and tips on upgrading your content, please check our [guide for upgrading language versions](https://docs.qualified.io/creating-content/challenges/upgrading-language-versions/#upgrading-language-versions).
   
 - **Performance issue when loading "Portfolio" tab of report card** 
 

--- a/content/changes.md
+++ b/content/changes.md
@@ -46,7 +46,7 @@ Learn about notable new features, fixes, and other improvements to the applicati
 
 - **ASCII 7 Segment Display challenge** 
 
-    This challenge tests the candidate's basic array and string manipulation.  
+    This challenge tests the candidate's basic array and string manipulation skills.
 
 :::info
 Note that Product Updates was on hiatus for 6 months. No major updates occurred during this time beyond standard bug fixes and challenges. We'll continue on a monthly basis going forward.

--- a/content/changes.md
+++ b/content/changes.md
@@ -40,7 +40,7 @@ Learn about notable new features, fixes, and other improvements to the applicati
   Signals customers only
   ::: 
 
-  Users were experiencing heavy lag, especially with scrolls, once the Portfolio tab was activated and the number of assessments results was 6 or more. This issue was successfully fixed.  
+    Users were experiencing heavy lag, especially with scrolls, once the Portfolio tab was activated and the number of assessments results was 6 or more. This issue was fixed.
     
 ### Challenges
 

--- a/content/changes.md
+++ b/content/changes.md
@@ -14,7 +14,9 @@ Learn about notable new features, fixes, and other improvements to the applicati
  
 - **Qualified and Learnosity Integration** 
 
-    [Qualified and Learnosity Partnership: Bridging the Skills Gap with Developer Assessments](https://andela.com/blog-posts/qualified-and-learnosity-partnership-bridging-the-skills-gap-with-developer-assessments)
+   We've partnered with Learnosity to integrate Qualified coding challenges into Learnosity assessments! Our custom question type enables students to solve project and classic coding challenges in a Learnosity assessment, powered by Qualified's Embed engine. 
+
+  Check our post [Qualified and Learnosity Partnership: Bridging the Skills Gap with Developer Assessments](https://andela.com/blog-posts/qualified-and-learnosity-partnership-bridging-the-skills-gap-with-developer-assessments) to learn more.
 
 ### Improvements 
 

--- a/content/changes.md
+++ b/content/changes.md
@@ -40,8 +40,8 @@ Learn about notable new features, fixes, and other improvements to the applicati
   Signals customers only
   ::: 
 
-    We fixed an issue with users experiencing heavy lag in the report card Portfolio tab when many assessment results were present.
-
+  Users were experiencing heavy lag, especially with scrolls, once the Portfolio tab was activated and the number of assessments results was 6 or more. This issue was successfully fixed.  
+    
 ### Challenges
 
 - **ASCII 7 Segment Display challenge** 

--- a/content/changes.md
+++ b/content/changes.md
@@ -40,7 +40,7 @@ Learn about notable new features, fixes, and other improvements to the applicati
   Signals customers only
   ::: 
 
-    Users were experiencing heavy lag, especially with scrolls, once the Portfolio tab was activated and the number of assessments results was 6 or more. This issue was fixed.
+    Users were experiencing heavy lag, especially with scrolls, once the Portfolio tab was activated and the number of assessment results was 6 or more. This issue was fixed.
     
 ### Challenges
 

--- a/content/changes.md
+++ b/content/changes.md
@@ -40,7 +40,7 @@ Learn about notable new features, fixes, and other improvements to the applicati
   Signals customers only
   ::: 
 
-    Users were experiencing heavy lag, especially with scrolls, once Portfolio tab was activated and the number of assessments results was exceeding 6 or more. This issue was successfully fixed.  
+    We fixed an issue with users experiencing heavy lag in the report card Portfolio tab when many assessment results were present.
 
 ### Challenges
 

--- a/content/changes.md
+++ b/content/changes.md
@@ -33,7 +33,7 @@ Learn about notable new features, fixes, and other improvements to the applicati
 - **Performance issue when loading "Portfolio" tab of report card**
 
   :::note
-  Signal’s customers only
+  Signals customers only
   ::: 
 
     Users were experiencing heavy lag, especially with scrolls, once Portfolio tab was activated and the number of assessments results was exceeding 6 or more. This issue was successfully fixed.  

--- a/content/changes.md
+++ b/content/changes.md
@@ -8,6 +8,46 @@ summary: 'Learn about new features, fixes, and other improvements'
 
 Learn about notable new features, fixes, and other improvements to the application!
 
+## January, 2024 
+
+### Features 
+ 
+- **Learnosity Partnership Integration** 
+
+    [Learnosity](https://learnosity.com/) has officially announced our partnership and integration into their platform to their custom base, via website, newsletter, and socials! 
+
+    This integration allows us to expand our reach into the L&D space, acting as an important add-on component within Learnosity's deep offering across many different learning domains. We've closed our first partner sale via iCEV, and already have other potential deals beginning to surface.       We will be presenting internally to their sales team later this month to further deepen our partnership and enable their sales team to bring more business to us.  
+
+    [Release Announcement](https://help.learnosity.com/hc/en-us/articles/14870489871133-2024-1-LTS-Release-Announcement)
+
+    [Partner Page](https://learnosity.com/company/partners/partners-directory/qualified/)
+
+
+### Improvements 
+
+- **Erlang 26** 
+
+    Erlang 26 is now supported within project challenges. 
+
+- **Elixir 1.15** 
+
+    Elixir 1.15 is now supported within project challenges.
+
+- **Add deprecated language version labels** 
+
+    A new “deprecated” label was added on old language versions in the challenge edit and detail views, visible to teams and content managers with the purpose of providing our users with more legibility of what are the available language versions to use. For further information please check       our [documentation](https://docs.qualified.io/creating-content/challenges/upgrading-language-versions/#upgrading-language-versions) 
+  
+- **Performance issue when loading "Portfolio" tab of report card** 
+
+    Users were experiencing heavy lag, especially with scrolls, once Portfolio tab was activated and the number of assessments results was exceeding 6 or more. This issue was successfully fixed.  
+
+### Challenges
+
+- **ASCII 7 Segment Display challenge** 
+
+    This challenge tests the candidate's basic array and string manipulation.  
+
+
 ## July 13, 2023
 
 ### Features

--- a/content/changes.md
+++ b/content/changes.md
@@ -12,7 +12,7 @@ Learn about notable new features, fixes, and other improvements to the applicati
 
 ### Features 
  
-- **Learnosity Partnership Integration** 
+- **Qualified and Learnosity Integration** 
 
     [Qualified and Learnosity Partnership: Bridging the Skills Gap with Developer Assessments](https://andela.com/blog-posts/qualified-and-learnosity-partnership-bridging-the-skills-gap-with-developer-assessments)
 

--- a/content/changes.md
+++ b/content/changes.md
@@ -32,7 +32,9 @@ Learn about notable new features, fixes, and other improvements to the applicati
 
     A new "deprecated" label was added to old language versions in the challenge edit and detail views. This helps content managers identify which language versions will be removed in the future. For further information and tips on upgrading your content, please check our [guide for upgrading language versions](https://docs.qualified.io/creating-content/challenges/upgrading-language-versions/#upgrading-language-versions).
   
-- **Performance issue when loading "Portfolio" tab of report card**
+### Bug Fixes
+
+- **Fixed report card "Portfolio" tab performance issue**
 
   :::note
   Signals customers only


### PR DESCRIPTION
**Context**
With the purpose of publishing again the monthly product updates starting since January 2024 we have included features, improvements and content related topics that are relevant for our customers.

I used the information registered in the releases we done during January.

**Reference**
https://andela.atlassian.net/browse/QUAL-775
